### PR TITLE
Ap 419 fix external convs find one method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebot7/sdk",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "e-bot7 javascript SDK. A thin client for developing e-bot7 applications.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebot7/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "e-bot7 javascript SDK. A thin client for developing e-bot7 applications.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/classes/conversations/conversations.interfaces.ts
+++ b/src/lib/classes/conversations/conversations.interfaces.ts
@@ -27,7 +27,7 @@ export interface IEbot7Conversation {
 }
 
 export interface IEbot7ConversationOutput {
-  item: IEbot7Conversation;
+  item: IEbot7Conversation | null;
 }
 
 export interface IEbot7ConversationExternalData {

--- a/src/lib/classes/external-conversations/external-conversations.client.ts
+++ b/src/lib/classes/external-conversations/external-conversations.client.ts
@@ -1,11 +1,11 @@
 import {
   IEbot7GetExternalConversationOptions,
-  IUpdateExternalConversationOptions
+  IUpdateExternalConversationOptions,
 } from '.';
 import { Ebot7Client } from '../client';
 import {
   IEbot7ConversationOutput,
-  IEbot7CreateConversationOptions
+  IEbot7CreateConversationOptions,
 } from '../conversations';
 
 export class Ebot7ExternalConversationClient {

--- a/src/lib/classes/external-conversations/external-conversations.client.ts
+++ b/src/lib/classes/external-conversations/external-conversations.client.ts
@@ -1,11 +1,11 @@
 import {
   IEbot7GetExternalConversationOptions,
-  IUpdateExternalConversationOptions,
+  IUpdateExternalConversationOptions
 } from '.';
 import { Ebot7Client } from '../client';
 import {
   IEbot7ConversationOutput,
-  IEbot7CreateConversationOptions,
+  IEbot7CreateConversationOptions
 } from '../conversations';
 
 export class Ebot7ExternalConversationClient {
@@ -23,9 +23,11 @@ export class Ebot7ExternalConversationClient {
   ): Promise<IEbot7ConversationOutput> {
     const url = `bots/${options.botId}/external-convs/${options.externalId}`;
     const result = await this.client.get(url);
-    // Return first item in list of return conversations. 
+    // Return first item in list of return conversations.
     // Adapt output to expected return type.
-    return {item: result.data?.items?.[0]};
+    if (result.data?.items && result.data?.items.length) {
+      return { item: result.data.items[0] };
+    } else return { item: null };
   }
 
   /**

--- a/src/lib/classes/external-conversations/external-conversations.client.ts
+++ b/src/lib/classes/external-conversations/external-conversations.client.ts
@@ -23,8 +23,9 @@ export class Ebot7ExternalConversationClient {
   ): Promise<IEbot7ConversationOutput> {
     const url = `bots/${options.botId}/external-convs/${options.externalId}`;
     const result = await this.client.get(url);
-
-    return result.data;
+    // Return first item in list of return conversations. 
+    // Adapt output to expected return type.
+    return {item: result.data?.items?.[0]};
   }
 
   /**


### PR DESCRIPTION
### Introduced changes:
-  Fixes external conversation findOne method be enforcing that it returns the first item in the return data list if any.

### How to test:
- Run `yarn install`
- Run `yarn test:unit`
